### PR TITLE
Remove limitation of minimum 2 coauthors

### DIFF
--- a/git-coauthor
+++ b/git-coauthor
@@ -72,8 +72,6 @@ function author_match() {
 function setup_pair() {
   local commit_template
 
-  [[ "$#" -lt 2 ]] && { err "need at least two authors to pair!" && return 1; }
-
   commit_template=""
   for i in "$@"; do
     local full_author


### PR DESCRIPTION
This PR is just to remove the limitation of the minimum need of 2 people to make coauthor. At least today is totally ok to use an author and a coauthor, so this limit has no sense in my opinion any longer.